### PR TITLE
Fix autoloading issue

### DIFF
--- a/Mplusqapiclient.php
+++ b/Mplusqapiclient.php
@@ -6557,7 +6557,7 @@ class MplusQAPIDataParser
 
 //------------------------------------------------------------------------------
 
-if ( ! class_exists('MplusQAPIException')) {
+if ( ! class_exists('MplusQAPIException', false)) {
   class MplusQAPIException extends Exception
   {
 


### PR DESCRIPTION
If you trigger `class_exists` by default autoloader will be started which causes the following exception `Warning: include(MplusQAPIException.php): failed to open stream: No such file or directory`. Only check if the class already exists but never try to autoload it will fix this issue.